### PR TITLE
Apply Holi festival color theme across the app

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,19 +1,19 @@
 @import "tailwindcss";
 
 :root {
-  --bg-primary: #0a0a1a;
-  --bg-secondary: #0d0d28;
-  --glass-bg: rgba(255, 255, 255, 0.05);
-  --glass-border: rgba(255, 255, 255, 0.1);
-  --glass-hover: rgba(255, 255, 255, 0.08);
-  --accent-violet: #7c3aed;
-  --accent-violet-light: #a78bfa;
-  --accent-cyan: #06b6d4;
-  --accent-cyan-light: #67e8f9;
-  --text-primary: #f1f5f9;
-  --text-secondary: #94a3b8;
-  --text-muted: #64748b;
-  --success: #10b981;
+  --bg-primary: #fffef0;
+  --bg-secondary: #fff3e0;
+  --glass-bg: rgba(255, 255, 255, 0.72);
+  --glass-border: rgba(233, 30, 140, 0.2);
+  --glass-hover: rgba(255, 255, 255, 0.88);
+  --accent-violet: #e91e8c;
+  --accent-violet-light: #f48fb1;
+  --accent-cyan: #ff6b35;
+  --accent-cyan-light: #ffab91;
+  --text-primary: #1a1a2e;
+  --text-secondary: #5a4a6e;
+  --text-muted: #8a7a9e;
+  --success: #22c55e;
   --danger: #ef4444;
   --warning: #f59e0b;
 }
@@ -53,7 +53,7 @@ body {
 }
 
 .btn-glow:hover {
-  box-shadow: 0 0 24px rgba(124, 58, 237, 0.5), 0 0 48px rgba(6, 182, 212, 0.2);
+  box-shadow: 0 0 24px rgba(233, 30, 140, 0.5), 0 0 48px rgba(255, 107, 53, 0.2);
   transform: translateY(-1px);
 }
 
@@ -62,9 +62,9 @@ body {
 }
 
 @keyframes pulse-glow {
-  0% { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.4); }
-  70% { box-shadow: 0 0 0 14px rgba(124, 58, 237, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0); }
+  0% { box-shadow: 0 0 0 0 rgba(233, 30, 140, 0.4); }
+  70% { box-shadow: 0 0 0 14px rgba(233, 30, 140, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(233, 30, 140, 0); }
 }
 
 @keyframes float {

--- a/frontend/src/pages/CreateGame/CreateGame.jsx
+++ b/frontend/src/pages/CreateGame/CreateGame.jsx
@@ -1,12 +1,12 @@
 import React, { useState } from "react";
 
 const glassCard = {
-  background: "rgba(255, 255, 255, 0.05)",
+  background: "rgba(255, 255, 255, 0.82)",
   backdropFilter: "blur(24px)",
   WebkitBackdropFilter: "blur(24px)",
-  border: "1px solid rgba(255, 255, 255, 0.1)",
+  border: "1px solid rgba(233, 30, 140, 0.2)",
   borderRadius: 20,
-  boxShadow: "0 8px 40px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.08)",
+  boxShadow: "0 8px 40px rgba(233,30,140,0.12), inset 0 1px 0 rgba(255,255,255,0.9)",
   padding: "40px 32px 32px 32px",
   minWidth: 340,
   maxWidth: 420,
@@ -16,16 +16,16 @@ const glassCard = {
   overflow: "hidden",
 };
 
-const inputStyle = (accentColor = "#7c3aed") => ({
+const inputStyle = (accentColor = "#e91e8c") => ({
   width: "100%",
   padding: "12px 14px",
   borderRadius: 10,
-  border: `1.5px solid rgba(255,255,255,0.12)`,
+  border: `1.5px solid rgba(233,30,140,0.2)`,
   fontSize: 16,
   outline: "none",
   fontWeight: 500,
-  background: "rgba(255,255,255,0.06)",
-  color: "#f1f5f9",
+  background: "rgba(255,255,255,0.7)",
+  color: "#1a1a2e",
   transition: "border 0.2s, box-shadow 0.2s",
   boxSizing: "border-box",
 });
@@ -36,14 +36,14 @@ const btnPrimary = (disabled) => ({
   padding: "12px 0",
   borderRadius: 10,
   background: disabled
-    ? "rgba(255,255,255,0.08)"
-    : "linear-gradient(135deg, #7c3aed 0%, #06b6d4 100%)",
-  color: disabled ? "#64748b" : "#fff",
+    ? "rgba(233,30,140,0.12)"
+    : "linear-gradient(135deg, #e91e8c 0%, #ff6b35 100%)",
+  color: disabled ? "#8a7a9e" : "#fff",
   border: "none",
   fontWeight: 700,
   marginTop: 8,
   cursor: disabled ? "not-allowed" : "pointer",
-  boxShadow: disabled ? "none" : "0 4px 20px rgba(124, 58, 237, 0.35)",
+  boxShadow: disabled ? "none" : "0 4px 20px rgba(233, 30, 140, 0.35)",
   transition: "box-shadow 0.2s, transform 0.12s",
   letterSpacing: "0.4px",
 });
@@ -53,9 +53,9 @@ const btnSecondary = {
   fontSize: 15,
   padding: "10px 0",
   borderRadius: 10,
-  background: "rgba(255,255,255,0.06)",
-  color: "#94a3b8",
-  border: "1px solid rgba(255,255,255,0.1)",
+  background: "rgba(233,30,140,0.06)",
+  color: "#5a4a6e",
+  border: "1px solid rgba(233,30,140,0.15)",
   fontWeight: 600,
   marginTop: 14,
   cursor: "pointer",
@@ -88,7 +88,7 @@ function CreateGamePage({ send, loading, error, state }) {
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        background: "#0a0a1a",
+        background: "#fffef0",
         padding: "20px",
         fontFamily: "Inter, Segoe UI, system-ui, sans-serif",
         position: "relative",
@@ -98,12 +98,12 @@ function CreateGamePage({ send, loading, error, state }) {
       {/* Ambient blobs */}
       <div style={{
         position: "fixed", top: "-15%", left: "-10%", width: "55%", height: "55%",
-        background: "radial-gradient(circle, rgba(124,58,237,0.16) 0%, transparent 70%)",
+        background: "radial-gradient(circle, rgba(233,30,140,0.18) 0%, transparent 70%)",
         pointerEvents: "none", zIndex: 0,
       }} />
       <div style={{
         position: "fixed", bottom: "-10%", right: "-10%", width: "45%", height: "45%",
-        background: "radial-gradient(circle, rgba(6,182,212,0.12) 0%, transparent 70%)",
+        background: "radial-gradient(circle, rgba(255,107,53,0.15) 0%, transparent 70%)",
         pointerEvents: "none", zIndex: 0,
       }} />
 
@@ -117,17 +117,17 @@ function CreateGamePage({ send, loading, error, state }) {
           }
         }
         .create-game-input:focus {
-          border-color: rgba(124,58,237,0.7) !important;
-          box-shadow: 0 0 0 3px rgba(124,58,237,0.15) !important;
+          border-color: rgba(233,30,140,0.7) !important;
+          box-shadow: 0 0 0 3px rgba(233,30,140,0.15) !important;
         }
-        .create-game-input::placeholder { color: #4b5563; }
+        .create-game-input::placeholder { color: #8a7a9e; }
         .btn-primary-glow:hover:not(:disabled) {
-          box-shadow: 0 0 32px rgba(124,58,237,0.55), 0 0 64px rgba(6,182,212,0.2) !important;
+          box-shadow: 0 0 32px rgba(233,30,140,0.55), 0 0 64px rgba(255,107,53,0.2) !important;
           transform: translateY(-1px);
         }
         .btn-secondary-ghost:hover {
-          background: rgba(255,255,255,0.1) !important;
-          color: #f1f5f9 !important;
+          background: rgba(233,30,140,0.08) !important;
+          color: #1a1a2e !important;
         }
       `}</style>
 
@@ -135,27 +135,27 @@ function CreateGamePage({ send, loading, error, state }) {
         {/* Top accent bar */}
         <div style={{
           position: "absolute", top: 0, left: 0, right: 0, height: 3,
-          background: "linear-gradient(90deg, #7c3aed 0%, #06b6d4 100%)",
+          background: "linear-gradient(90deg, #e91e8c 0%, #ff6b35 100%)",
           borderRadius: "20px 20px 0 0",
         }} />
 
-        <h2 style={{ fontWeight: 800, fontSize: 26, marginBottom: 8, color: "#a78bfa", letterSpacing: 0.5 }}>
+        <h2 style={{ fontWeight: 800, fontSize: 26, marginBottom: 8, color: "#e91e8c", letterSpacing: 0.5 }}>
           {isSystemGame ? "⚔️ Play vs System" : "🎮 Create a New Game"}
         </h2>
-        <div style={{ color: "#64748b", marginBottom: 24, fontSize: 14.5, lineHeight: 1.65 }}>
+        <div style={{ color: "#5a4a6e", marginBottom: 24, fontSize: 14.5, lineHeight: 1.65 }}>
           {isSystemGame ? (
             <>
               Challenge the AI to a guessing duel!<br />
               Enter your name and a secret 4-digit number.<br />
               <span style={{ color: "#f59e0b", fontWeight: 600 }}>All digits must be unique!</span><br />
-              <span style={{ color: "#06b6d4", fontWeight: 500 }}>The system will auto-join and play!</span>
+              <span style={{ color: "#ff6b35", fontWeight: 500 }}>The system will auto-join and play!</span>
             </>
           ) : (
             <>
               Ready to challenge your friends?<br />
               Enter your name and a secret 4-digit number.<br />
               <span style={{ color: "#f59e0b", fontWeight: 600 }}>All digits must be unique!</span><br />
-              <span style={{ color: "#06b6d4", fontWeight: 500 }}>Share the Game ID after creating!</span>
+              <span style={{ color: "#ff6b35", fontWeight: 500 }}>Share the Game ID after creating!</span>
             </>
           )}
         </div>

--- a/frontend/src/pages/DailyChallenge/DailyChallenge.jsx
+++ b/frontend/src/pages/DailyChallenge/DailyChallenge.jsx
@@ -24,14 +24,14 @@ function GuessFeedback({ guesses }) {
               display: "flex",
               alignItems: "center",
               gap: 10,
-              background: "rgba(255,255,255,0.04)",
-              border: "1px solid rgba(255,255,255,0.07)",
+              background: "rgba(255,255,255,0.65)",
+              border: "1px solid rgba(233,30,140,0.1)",
               borderRadius: 10,
               padding: "7px 12px",
               animation: "slideIn 0.25s ease-out",
             }}
           >
-            <span style={{ color: "#475569", fontSize: "0.78rem", minWidth: 22, fontVariantNumeric: "tabular-nums" }}>
+            <span style={{ color: "#8a7a9e", fontSize: "0.78rem", minWidth: 22, fontVariantNumeric: "tabular-nums" }}>
               #{i + 1}
             </span>
             <div style={{ display: "flex", gap: 5 }}>
@@ -44,12 +44,12 @@ function GuessFeedback({ guesses }) {
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "center",
-                    background: "rgba(255,255,255,0.08)",
-                    border: "1px solid rgba(255,255,255,0.13)",
+                    background: "rgba(255,255,255,0.7)",
+                    border: "1px solid rgba(233,30,140,0.15)",
                     borderRadius: 6,
                     fontWeight: 700,
                     fontSize: "0.95rem",
-                    color: "#f1f5f9",
+                    color: "#1a1a2e",
                   }}
                 >
                   {d}
@@ -58,16 +58,16 @@ function GuessFeedback({ guesses }) {
             </div>
             <div style={{ display: "flex", gap: 3, marginLeft: 4 }}>
               {Array(g.correct_positions).fill(0).map((_, k) => (
-                <span key={`g${k}`} style={{ color: "#10b981", fontSize: 13 }}>●</span>
+                <span key={`g${k}`} style={{ color: "#22c55e", fontSize: 13 }}>●</span>
               ))}
               {Array(wrongPos).fill(0).map((_, k) => (
-                <span key={`y${k}`} style={{ color: "#f59e0b", fontSize: 13 }}>●</span>
+                <span key={`y${k}`} style={{ color: "#ffd700", fontSize: 13 }}>●</span>
               ))}
               {Array(wrong).fill(0).map((_, k) => (
-                <span key={`w${k}`} style={{ color: "#1e293b", fontSize: 13 }}>●</span>
+                <span key={`w${k}`} style={{ color: "#d1a0b0", fontSize: 13 }}>●</span>
               ))}
             </div>
-            <span style={{ color: "#475569", fontSize: "0.72rem", marginLeft: "auto", fontVariantNumeric: "tabular-nums" }}>
+            <span style={{ color: "#8a7a9e", fontSize: "0.72rem", marginLeft: "auto", fontVariantNumeric: "tabular-nums" }}>
               {g.correct_positions}✓ {wrongPos}~
             </span>
           </div>
@@ -175,12 +175,12 @@ export default function DailyChallenge() {
   }
 
   const cardStyle = {
-    background: "rgba(255,255,255,0.05)",
+    background: "rgba(255,255,255,0.8)",
     backdropFilter: "blur(20px)",
     WebkitBackdropFilter: "blur(20px)",
-    border: "1px solid rgba(255,255,255,0.1)",
+    border: "1px solid rgba(255,107,53,0.22)",
     borderRadius: 18,
-    boxShadow: "0 8px 32px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.08)",
+    boxShadow: "0 8px 32px rgba(255,107,53,0.12), inset 0 1px 0 rgba(255,255,255,0.9)",
     padding: "1.5rem",
     width: "100%",
     maxWidth: 460,
@@ -189,7 +189,7 @@ export default function DailyChallenge() {
   };
 
   const btnGradient = {
-    background: "linear-gradient(135deg, #7c3aed 0%, #06b6d4 100%)",
+    background: "linear-gradient(135deg, #e91e8c 0%, #ff6b35 100%)",
     color: "#fff",
     border: "none",
     borderRadius: 10,
@@ -197,7 +197,7 @@ export default function DailyChallenge() {
     fontSize: "1rem",
     fontWeight: 700,
     cursor: "pointer",
-    boxShadow: "0 4px 16px rgba(124,58,237,0.3)",
+    boxShadow: "0 4px 16px rgba(233,30,140,0.3)",
     transition: "box-shadow 0.2s, transform 0.12s",
     width: "100%",
     marginTop: 12,
@@ -205,14 +205,14 @@ export default function DailyChallenge() {
 
   const btnAmber = {
     ...btnGradient,
-    background: "linear-gradient(135deg, #f59e0b 0%, #f97316 100%)",
-    boxShadow: "0 4px 16px rgba(245,158,11,0.3)",
+    background: "linear-gradient(135deg, #ffd700 0%, #ff6b35 100%)",
+    boxShadow: "0 4px 16px rgba(255,107,53,0.3)",
   };
 
   const ghostBtn = {
-    background: "rgba(255,255,255,0.07)",
-    color: "#94a3b8",
-    border: "1px solid rgba(255,255,255,0.1)",
+    background: "rgba(255,255,255,0.6)",
+    color: "#5a4a6e",
+    border: "1px solid rgba(233,30,140,0.15)",
     borderRadius: 8,
     padding: "0.5rem 1rem",
     fontSize: "0.88rem",
@@ -231,8 +231,8 @@ export default function DailyChallenge() {
     <div
       style={{
         minHeight: "100vh",
-        background: "#0a0a1a",
-        color: "#f1f5f9",
+        background: "#fffef0",
+        color: "#1a1a2e",
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
@@ -256,26 +256,26 @@ export default function DailyChallenge() {
       `}</style>
 
       {/* Background blobs */}
-      <div style={{ position:"fixed", top:"-20%", left:"-10%", width:"55%", height:"55%", background:"radial-gradient(circle, rgba(245,158,11,0.13) 0%, transparent 70%)", pointerEvents:"none", zIndex:0 }} />
-      <div style={{ position:"fixed", bottom:"-10%", right:"-10%", width:"45%", height:"45%", background:"radial-gradient(circle, rgba(124,58,237,0.1) 0%, transparent 70%)", pointerEvents:"none", zIndex:0 }} />
+      <div style={{ position:"fixed", top:"-20%", left:"-10%", width:"55%", height:"55%", background:"radial-gradient(circle, rgba(255,215,0,0.2) 0%, transparent 70%)", pointerEvents:"none", zIndex:0 }} />
+      <div style={{ position:"fixed", bottom:"-10%", right:"-10%", width:"45%", height:"45%", background:"radial-gradient(circle, rgba(255,107,53,0.15) 0%, transparent 70%)", pointerEvents:"none", zIndex:0 }} />
 
       {/* Top nav */}
       <div style={{ width:"100%", maxWidth:960, display:"flex", justifyContent:"space-between", alignItems:"center", marginBottom:"1.25rem", position:"relative", zIndex:1 }}>
         <button onClick={() => navigate("/")} style={ghostBtn}>← Home</button>
         <div style={{ textAlign:"center" }}>
-          <h1 style={{ fontSize:"1.8rem", fontWeight:800, margin:0, background:"linear-gradient(135deg, #fbbf24 0%, #f97316 50%, #a78bfa 100%)", WebkitBackgroundClip:"text", WebkitTextFillColor:"transparent", backgroundClip:"text" }}>
+          <h1 style={{ fontSize:"1.8rem", fontWeight:800, margin:0, background:"linear-gradient(135deg, #e91e8c 0%, #ffd700 50%, #22c55e 100%)", WebkitBackgroundClip:"text", WebkitTextFillColor:"transparent", backgroundClip:"text" }}>
             Daily Challenge
           </h1>
-          {dateDisplay && <p style={{ color:"#64748b", margin:"2px 0 0", fontSize:"0.8rem" }}>{dateDisplay}</p>}
+          {dateDisplay && <p style={{ color:"#8a7a9e", margin:"2px 0 0", fontSize:"0.8rem" }}>{dateDisplay}</p>}
         </div>
-        <button onClick={() => navigate("/leaderboard")} style={{ ...ghostBtn, color:"#fbbf24" }}>🏆 Board</button>
+        <button onClick={() => navigate("/leaderboard")} style={{ ...ghostBtn, color:"#ff6b35" }}>🏆 Board</button>
       </div>
 
       {/* Name entry */}
       {phase === "name_entry" && (
         <div style={{ ...cardStyle, maxWidth:420, animation:"popIn 0.35s ease-out", position:"relative", zIndex:1 }}>
-          <h2 style={{ margin:"0 0 0.4rem", fontWeight:700, fontSize:"1.05rem", color:"#fbbf24" }}>Enter your name to begin</h2>
-          <p style={{ color:"#64748b", fontSize:"0.85rem", margin:"0 0 1.1rem" }}>
+          <h2 style={{ margin:"0 0 0.4rem", fontWeight:700, fontSize:"1.05rem", color:"#ff6b35" }}>Enter your name to begin</h2>
+          <p style={{ color:"#5a4a6e", fontSize:"0.85rem", margin:"0 0 1.1rem" }}>
             Your name appears on the leaderboard when you solve today's puzzle.
           </p>
           <form onSubmit={handleStart} style={{ display:"flex", flexDirection:"column", gap:10 }}>
@@ -286,7 +286,7 @@ export default function DailyChallenge() {
               placeholder="Your name"
               autoFocus
               maxLength={24}
-              style={{ background:"rgba(255,255,255,0.07)", border:"1px solid rgba(255,255,255,0.12)", borderRadius:10, padding:"0.75rem 1rem", color:"#f1f5f9", fontSize:"1rem", outline:"none", width:"100%", boxSizing:"border-box" }}
+              style={{ background:"rgba(255,255,255,0.7)", border:"1px solid rgba(255,107,53,0.22)", borderRadius:10, padding:"0.75rem 1rem", color:"#1a1a2e", fontSize:"1rem", outline:"none", width:"100%", boxSizing:"border-box" }}
             />
             {error && <div style={{ color:"#ef4444", fontSize:"0.85rem" }}>{error}</div>}
             <button type="submit" style={{ ...btnAmber, marginTop:8 }} disabled={isLoading || !playerName.trim()}>
@@ -316,23 +316,23 @@ export default function DailyChallenge() {
           <div style={cardStyle}>
             {/* Stats bar */}
             <div style={{ display:"flex", justifyContent:"space-between", alignItems:"center", marginBottom:14, paddingBottom:12, borderBottom:"1px solid rgba(255,255,255,0.07)" }}>
-              <span style={{ color:"#94a3b8", fontSize:"0.85rem" }}>
-                Hi, <strong style={{ color:"#f1f5f9" }}>{playerName}</strong>
+              <span style={{ color:"#5a4a6e", fontSize:"0.85rem" }}>
+                Hi, <strong style={{ color:"#1a1a2e" }}>{playerName}</strong>
               </span>
-              <span style={{ background:"rgba(245,158,11,0.15)", border:"1px solid rgba(245,158,11,0.3)", borderRadius:8, padding:"3px 10px", color:"#fbbf24", fontWeight:700, fontSize:"0.92rem", fontVariantNumeric:"tabular-nums" }}>
+              <span style={{ background:"rgba(255,107,53,0.12)", border:"1px solid rgba(255,107,53,0.3)", borderRadius:8, padding:"3px 10px", color:"#ea580c", fontWeight:700, fontSize:"0.92rem", fontVariantNumeric:"tabular-nums" }}>
                 ⏱ {formatTime(elapsed)}
               </span>
-              <span style={{ color:"#64748b", fontSize:"0.82rem" }}>
+              <span style={{ color:"#8a7a9e", fontSize:"0.82rem" }}>
                 {guesses.length} {guesses.length === 1 ? "guess" : "guesses"}
               </span>
             </div>
 
             {/* Legend (first time only) */}
             {guesses.length === 0 && (
-              <div style={{ display:"flex", gap:14, justifyContent:"center", marginBottom:14, fontSize:"0.78rem", color:"#64748b" }}>
-                <span><span style={{ color:"#10b981" }}>●</span> Right position</span>
-                <span><span style={{ color:"#f59e0b" }}>●</span> Wrong position</span>
-                <span><span style={{ color:"#1e293b" }}>●</span> Not in number</span>
+              <div style={{ display:"flex", gap:14, justifyContent:"center", marginBottom:14, fontSize:"0.78rem", color:"#8a7a9e" }}>
+                <span><span style={{ color:"#22c55e" }}>●</span> Right position</span>
+                <span><span style={{ color:"#ffd700" }}>●</span> Wrong position</span>
+                <span><span style={{ color:"#d1a0b0" }}>●</span> Not in number</span>
               </div>
             )}
 
@@ -341,7 +341,7 @@ export default function DailyChallenge() {
 
             {/* PIN input */}
             <form onSubmit={handleGuess}>
-              <p style={{ color:"#94a3b8", fontSize:"0.82rem", margin:"0 0 10px", textAlign:"center" }}>
+              <p style={{ color:"#5a4a6e", fontSize:"0.82rem", margin:"0 0 10px", textAlign:"center" }}>
                 Guess a 4-digit number — all digits unique
               </p>
               <div style={{ display:"flex", gap:10, justifyContent:"center", marginBottom:10 }}>
@@ -362,10 +362,10 @@ export default function DailyChallenge() {
                       textAlign: "center",
                       fontSize: "1.5rem",
                       fontWeight: 700,
-                      background: pinDigits[i] ? "rgba(245,158,11,0.1)" : "rgba(255,255,255,0.07)",
-                      border: `2px solid ${pinDigits[i] ? "rgba(245,158,11,0.5)" : "rgba(255,255,255,0.12)"}`,
+                      background: pinDigits[i] ? "rgba(255,107,53,0.1)" : "rgba(255,255,255,0.7)",
+                      border: `2px solid ${pinDigits[i] ? "rgba(255,107,53,0.5)" : "rgba(233,30,140,0.18)"}`,
                       borderRadius: 10,
-                      color: "#f1f5f9",
+                      color: "#1a1a2e",
                       outline: "none",
                       caretColor: "transparent",
                       transition: "border-color 0.15s, background 0.15s",
@@ -415,30 +415,30 @@ export default function DailyChallenge() {
             ...cardStyle,
             maxWidth: 460,
             textAlign: "center",
-            border: "1px solid rgba(245,158,11,0.35)",
-            boxShadow: "0 8px 40px rgba(245,158,11,0.18), inset 0 1px 0 rgba(255,255,255,0.08)",
+            border: "1px solid rgba(255,107,53,0.35)",
+            boxShadow: "0 8px 40px rgba(255,107,53,0.2), inset 0 1px 0 rgba(255,255,255,0.9)",
             animation: "popIn 0.4s ease-out",
             position: "relative",
             zIndex: 1,
           }}
         >
           <div style={{ fontSize: "3rem", marginBottom: 8 }}>🎉</div>
-          <h2 style={{ margin:"0 0 0.2rem", fontWeight:800, fontSize:"1.55rem", background:"linear-gradient(135deg, #fbbf24 0%, #f97316 100%)", WebkitBackgroundClip:"text", WebkitTextFillColor:"transparent", backgroundClip:"text" }}>
+          <h2 style={{ margin:"0 0 0.2rem", fontWeight:800, fontSize:"1.55rem", background:"linear-gradient(135deg, #e91e8c 0%, #ff6b35 100%)", WebkitBackgroundClip:"text", WebkitTextFillColor:"transparent", backgroundClip:"text" }}>
             You cracked it!
           </h2>
-          <p style={{ color:"#94a3b8", margin:"0 0 1.4rem" }}>
-            Well done, <strong style={{ color:"#f1f5f9" }}>{playerName}</strong>!
+          <p style={{ color:"#5a4a6e", margin:"0 0 1.4rem" }}>
+            Well done, <strong style={{ color:"#1a1a2e" }}>{playerName}</strong>!
           </p>
 
           <div style={{ display:"flex", justifyContent:"center", gap:32, marginBottom:20 }}>
             <div style={{ textAlign:"center" }}>
-              <div style={{ fontSize:"2.2rem", fontWeight:800, color:"#a78bfa" }}>{guesses.length}</div>
-              <div style={{ color:"#64748b", fontSize:"0.78rem" }}>Guesses</div>
+              <div style={{ fontSize:"2.2rem", fontWeight:800, color:"#e91e8c" }}>{guesses.length}</div>
+              <div style={{ color:"#8a7a9e", fontSize:"0.78rem" }}>Guesses</div>
             </div>
-            <div style={{ width:1, background:"rgba(255,255,255,0.08)" }} />
+            <div style={{ width:1, background:"rgba(233,30,140,0.15)" }} />
             <div style={{ textAlign:"center" }}>
-              <div style={{ fontSize:"2.2rem", fontWeight:800, color:"#fbbf24" }}>{formatTime(timeTaken ?? elapsed)}</div>
-              <div style={{ color:"#64748b", fontSize:"0.78rem" }}>Time</div>
+              <div style={{ fontSize:"2.2rem", fontWeight:800, color:"#ff6b35" }}>{formatTime(timeTaken ?? elapsed)}</div>
+              <div style={{ color:"#8a7a9e", fontSize:"0.78rem" }}>Time</div>
             </div>
           </div>
 

--- a/frontend/src/pages/Game/Game.jsx
+++ b/frontend/src/pages/Game/Game.jsx
@@ -4,21 +4,21 @@ import ScratchPad from "./ScratchPad";
 import ENDPOINTS from "../../machine/endpoints";
 
 /* ── Design tokens ─────────────────────────────────────────── */
-const PAGE_BG = "#0a0a1a";
+const PAGE_BG = "#fffef0";
 const GLASS = {
-  background: "rgba(255,255,255,0.05)",
+  background: "rgba(255,255,255,0.75)",
   backdropFilter: "blur(20px)",
   WebkitBackdropFilter: "blur(20px)",
-  border: "1px solid rgba(255,255,255,0.1)",
+  border: "1px solid rgba(233,30,140,0.18)",
   borderRadius: 16,
-  boxShadow: "0 8px 32px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.07)",
+  boxShadow: "0 8px 32px rgba(233,30,140,0.1), inset 0 1px 0 rgba(255,255,255,0.9)",
 };
 
-// Player accent palettes (dark theme)
+// Player accent palettes (Holi theme)
 const PALETTES = {
-  player1: { border: "#7c3aed", bg: "rgba(124,58,237,0.08)", text: "#a78bfa", glow: "rgba(124,58,237,0.3)" },
-  player2: { border: "#06b6d4", bg: "rgba(6,182,212,0.08)", text: "#67e8f9", glow: "rgba(6,182,212,0.3)" },
-  system:  { border: "#f59e0b", bg: "rgba(245,158,11,0.08)", text: "#fbbf24", glow: "rgba(245,158,11,0.3)" },
+  player1: { border: "#e91e8c", bg: "rgba(233,30,140,0.07)", text: "#e91e8c", glow: "rgba(233,30,140,0.25)" },
+  player2: { border: "#22c55e", bg: "rgba(34,197,94,0.07)",  text: "#16a34a", glow: "rgba(34,197,94,0.25)" },
+  system:  { border: "#ff6b35", bg: "rgba(255,107,53,0.07)", text: "#ea580c", glow: "rgba(255,107,53,0.25)" },
 };
 
 function GamePage({ send, state }) {
@@ -116,13 +116,13 @@ function GamePage({ send, state }) {
     if (!guess) return null;
     return guess.toString().split("").map((digit, idx) => (
       <span key={idx} style={{
-        border: "1px solid rgba(255,255,255,0.15)",
+        border: "1px solid rgba(233,30,140,0.18)",
         borderRadius: 6,
         padding: "3px 8px",
         margin: "0 2px",
         fontWeight: 700,
-        background: "rgba(255,255,255,0.06)",
-        color: "#f1f5f9",
+        background: "rgba(255,255,255,0.7)",
+        color: "#1a1a2e",
         fontFamily: "monospace",
         fontSize: 15,
       }}>{digit}</span>
@@ -159,7 +159,7 @@ function GamePage({ send, state }) {
       padding: "20px",
       boxSizing: "border-box",
       fontFamily: "Inter, Segoe UI, system-ui, sans-serif",
-      color: "#f1f5f9",
+      color: "#1a1a2e",
       position: "relative",
       overflow: "hidden",
     }}>
@@ -177,9 +177,9 @@ function GamePage({ send, state }) {
 
       <style>{`
         @keyframes pulse-ring {
-          0% { box-shadow: 0 0 0 0 rgba(124,58,237,0.4); }
-          70% { box-shadow: 0 0 0 12px rgba(124,58,237,0); }
-          100% { box-shadow: 0 0 0 0 rgba(124,58,237,0); }
+          0% { box-shadow: 0 0 0 0 rgba(233,30,140,0.4); }
+          70% { box-shadow: 0 0 0 12px rgba(233,30,140,0); }
+          100% { box-shadow: 0 0 0 0 rgba(233,30,140,0); }
         }
         @keyframes spin { to { transform: rotate(360deg); } }
         @media (max-width: 900px) {
@@ -191,8 +191,8 @@ function GamePage({ send, state }) {
           .game-panel { padding: 12px 8px !important; font-size: 0.95rem !important; }
           .game-center { padding: 10px 4px !important; }
         }
-        .pin-input:focus { border-color: #7c3aed !important; box-shadow: 0 0 0 3px rgba(124,58,237,0.2) !important; }
-        .pin-input::placeholder { color: #334155; }
+        .pin-input:focus { border-color: #e91e8c !important; box-shadow: 0 0 0 3px rgba(233,30,140,0.2) !important; }
+        .pin-input::placeholder { color: #8a7a9e; }
       `}</style>
 
       {/* Game ID bar */}
@@ -212,15 +212,15 @@ function GamePage({ send, state }) {
           position: "relative",
           zIndex: 1,
         }}>
-          <span style={{ color: "#64748b" }}>Game ID:</span>
-          <span style={{ fontFamily: "monospace", fontWeight: 700, fontSize: 17, color: "#a78bfa", background: "rgba(124,58,237,0.1)", padding: "2px 10px", borderRadius: 6 }}>
+          <span style={{ color: "#8a7a9e" }}>Game ID:</span>
+          <span style={{ fontFamily: "monospace", fontWeight: 700, fontSize: 17, color: "#e91e8c", background: "rgba(233,30,140,0.1)", padding: "2px 10px", borderRadius: 6 }}>
             {gameId || "-"}
           </span>
           <button
             style={{
-              padding: "4px 12px", borderRadius: 6, border: "1px solid rgba(124,58,237,0.3)",
-              background: "rgba(124,58,237,0.1)", cursor: "pointer", fontWeight: 600,
-              color: "#a78bfa", fontSize: 13, transition: "background 0.2s",
+              padding: "4px 12px", borderRadius: 6, border: "1px solid rgba(233,30,140,0.3)",
+              background: "rgba(233,30,140,0.08)", cursor: "pointer", fontWeight: 600,
+              color: "#e91e8c", fontSize: 13, transition: "background 0.2s",
             }}
             onClick={() => {
               if (gameId) {
@@ -249,8 +249,8 @@ function GamePage({ send, state }) {
           fontSize: 16,
           textAlign: "center",
           maxWidth: 420,
-          color: "#fbbf24",
-          borderColor: "rgba(245,158,11,0.3)",
+          color: "#ff6b35",
+          borderColor: "rgba(255,107,53,0.3)",
           position: "relative",
           zIndex: 1,
         }}>
@@ -265,10 +265,10 @@ function GamePage({ send, state }) {
           maxWidth: 900,
           margin: "0 auto 24px auto",
           background: isWinner
-            ? "linear-gradient(135deg, rgba(16,185,129,0.2) 0%, rgba(6,182,212,0.2) 100%)"
+            ? "linear-gradient(135deg, rgba(34,197,94,0.15) 0%, rgba(255,215,0,0.15) 100%)"
             : winnerRole
-            ? "linear-gradient(135deg, rgba(239,68,68,0.2) 0%, rgba(124,58,237,0.15) 100%)"
-            : "rgba(255,255,255,0.05)",
+            ? "linear-gradient(135deg, rgba(239,68,68,0.15) 0%, rgba(233,30,140,0.1) 100%)"
+            : "rgba(255,255,255,0.5)",
           border: `1px solid ${isWinner ? "rgba(16,185,129,0.4)" : winnerRole ? "rgba(239,68,68,0.35)" : "rgba(255,255,255,0.1)"}`,
           borderRadius: 16,
           padding: "28px 16px",
@@ -278,7 +278,7 @@ function GamePage({ send, state }) {
           position: "relative",
           zIndex: 1,
         }}>
-          <h1 style={{ fontSize: 28, marginBottom: 8, fontWeight: 800, color: isWinner ? "#10b981" : winnerRole ? "#ef4444" : "#94a3b8" }}>
+          <h1 style={{ fontSize: 28, marginBottom: 8, fontWeight: 800, color: isWinner ? "#22c55e" : winnerRole ? "#ef4444" : "#5a4a6e" }}>
             {isFinished && gameData?.winner === null && !winnerRole
               ? "⏰ Time's up! The game ended in a draw."
               : isWinner
@@ -292,8 +292,8 @@ function GamePage({ send, state }) {
             style={{
               fontSize: 16, padding: "10px 28px", borderRadius: 10,
               background: isWinner
-                ? "linear-gradient(135deg,#10b981,#06b6d4)"
-                : "linear-gradient(135deg,#ef4444,#7c3aed)",
+                ? "linear-gradient(135deg,#22c55e,#ffd700)"
+                : "linear-gradient(135deg,#ef4444,#e91e8c)",
               color: "#fff", border: "none", marginTop: 8, cursor: "pointer",
               fontWeight: 700, boxShadow: "0 4px 16px rgba(0,0,0,0.3)",
             }}
@@ -319,26 +319,26 @@ function GamePage({ send, state }) {
           background: myPalette.bg,
         }}>
           <h3 style={{ color: myPalette.text, margin: "0 0 14px 0", fontSize: 17, fontWeight: 700 }}>
-            🎯 {myName} <span style={{ color: "#64748b", fontSize: 13, fontWeight: 500 }}>(You)</span>
+            🎯 {myName} <span style={{ color: "#8a7a9e", fontSize: 13, fontWeight: 500 }}>(You)</span>
           </h3>
           <div style={{ marginBottom: 14 }}>
-            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: 1, marginBottom: 4 }}>Your Secret Number</div>
+            <div style={{ color: "#8a7a9e", fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: 1, marginBottom: 4 }}>Your Secret Number</div>
             <div style={{ fontSize: 24, letterSpacing: 8, fontWeight: 800, color: myPalette.text, fontFamily: "monospace" }}>
-              {myNumber || <span style={{ color: "#334155", letterSpacing: 0 }}>—</span>}
+              {myNumber || <span style={{ color: "#8a7a9e", letterSpacing: 0 }}>—</span>}
             </div>
           </div>
           <div>
-            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: 1, marginBottom: 8 }}>
+            <div style={{ color: "#8a7a9e", fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: 1, marginBottom: 8 }}>
               Your Guesses
             </div>
             <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
               {(playerRole === "player1" ? player1Turns : player2Turns).length === 0 && (
-                <li style={{ color: "#334155", fontSize: 14 }}>No guesses yet.</li>
+                <li style={{ color: "#8a7a9e", fontSize: 14 }}>No guesses yet.</li>
               )}
               {(playerRole === "player1" ? player1Turns : player2Turns).map((t, idx) => (
                 <li key={idx} style={{ marginBottom: 8, display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
                   {renderGuess(t.guess)}
-                  <span style={{ fontSize: 12, color: "#64748b", marginLeft: 4 }}>
+                  <span style={{ fontSize: 12, color: "#8a7a9e", marginLeft: 4 }}>
                     ✓{t.correct_digits}d / ✓{t.correct_positions}p
                   </span>
                 </li>
@@ -355,27 +355,27 @@ function GamePage({ send, state }) {
           textAlign: "center",
           padding: 20,
         }}>
-          <h2 style={{ fontSize: 17, fontWeight: 700, marginBottom: 14, color: "#f1f5f9" }}>
+          <h2 style={{ fontSize: 17, fontWeight: 700, marginBottom: 14, color: "#1a1a2e" }}>
             {isSystemGame ? "⚔️ vs System AI" : "🎮 Game In Progress"}
           </h2>
 
           {/* Timer */}
-          <div style={{ marginBottom: 14, padding: "10px 16px", background: "rgba(255,255,255,0.04)", borderRadius: 10, border: "1px solid rgba(255,255,255,0.08)" }}>
-            <div style={{ fontSize: 11, color: "#64748b", fontWeight: 600, textTransform: "uppercase", letterSpacing: 1 }}>Timer</div>
-            <div style={{ fontSize: 26, fontWeight: 800, fontFamily: "monospace", color: timeLeft < 60 ? "#ef4444" : "#06b6d4", marginTop: 2 }}>
+          <div style={{ marginBottom: 14, padding: "10px 16px", background: "rgba(255,255,255,0.6)", borderRadius: 10, border: "1px solid rgba(233,30,140,0.12)" }}>
+            <div style={{ fontSize: 11, color: "#8a7a9e", fontWeight: 600, textTransform: "uppercase", letterSpacing: 1 }}>Timer</div>
+            <div style={{ fontSize: 26, fontWeight: 800, fontFamily: "monospace", color: timeLeft < 60 ? "#ef4444" : "#e91e8c", marginTop: 2 }}>
               {formatTime(timeLeft)}
             </div>
           </div>
 
           {/* Turn indicator */}
           <div style={{ marginBottom: 16, minHeight: 44, display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
-            <div style={{ fontSize: 12, color: "#64748b", fontWeight: 600, textTransform: "uppercase", letterSpacing: 1 }}>Current Turn</div>
-            <div style={{ fontSize: 14, color: "#94a3b8" }}>
+            <div style={{ fontSize: 12, color: "#8a7a9e", fontWeight: 600, textTransform: "uppercase", letterSpacing: 1 }}>Current Turn</div>
+            <div style={{ fontSize: 14, color: "#5a4a6e" }}>
               {turn === "player1" ? `${player1Name}` : turn === "player2" ? `${player2Name}${isSystemGame ? " (AI)" : ""}` : "—"}
             </div>
             {isMyTurn && !isSubmitting && (
               <span style={{
-                background: "linear-gradient(135deg, #7c3aed, #06b6d4)",
+                background: "linear-gradient(135deg, #e91e8c, #ff6b35)",
                 color: "#fff", fontWeight: 700, fontSize: 14,
                 borderRadius: 20, padding: "5px 16px",
                 animation: "pulse-ring 1.5s infinite",
@@ -385,18 +385,18 @@ function GamePage({ send, state }) {
             )}
             {isSubmitting && (
               <span style={{
-                background: "rgba(124,58,237,0.2)", color: "#a78bfa",
+                background: "rgba(233,30,140,0.1)", color: "#e91e8c",
                 fontWeight: 600, fontSize: 13, borderRadius: 20, padding: "5px 14px",
-                border: "1px solid rgba(124,58,237,0.3)",
+                border: "1px solid rgba(233,30,140,0.3)",
               }}>
                 ✅ Validating...
               </span>
             )}
             {!isMyTurn && turn === "player2" && isSystemGame && !isSubmitting && (
               <span style={{
-                background: "rgba(245,158,11,0.15)", color: "#fbbf24",
+                background: "rgba(255,107,53,0.12)", color: "#ea580c",
                 fontWeight: 600, fontSize: 13, borderRadius: 20, padding: "5px 14px",
-                border: "1px solid rgba(245,158,11,0.3)",
+                border: "1px solid rgba(255,107,53,0.3)",
               }}>
                 🤖 AI Thinking...
               </span>
@@ -423,11 +423,11 @@ function GamePage({ send, state }) {
                     style={{
                       width: 40, height: 48,
                       fontSize: 26, textAlign: "center",
-                      border: "1.5px solid rgba(255,255,255,0.1)",
+                      border: "1.5px solid rgba(233,30,140,0.18)",
                       borderRadius: 8,
-                      background: (isMyTurn && !isSubmitting) ? "rgba(124,58,237,0.1)" : "rgba(255,255,255,0.03)",
+                      background: (isMyTurn && !isSubmitting) ? "rgba(233,30,140,0.08)" : "rgba(255,255,255,0.5)",
                       outline: "none",
-                      fontWeight: 700, color: "#f1f5f9",
+                      fontWeight: 700, color: "#1a1a2e",
                       transition: "border 0.2s, box-shadow 0.2s",
                       fontFamily: "monospace",
                     }}
@@ -445,12 +445,12 @@ function GamePage({ send, state }) {
                 style={{
                   fontSize: 15, padding: "9px 24px", borderRadius: 8,
                   background: (isMyTurn && !isSubmitting && pin.join("").length === 4)
-                    ? "linear-gradient(135deg, #7c3aed, #06b6d4)"
-                    : "rgba(255,255,255,0.06)",
-                  color: (isMyTurn && !isSubmitting && pin.join("").length === 4) ? "#fff" : "#4b5563",
+                    ? "linear-gradient(135deg, #e91e8c, #ff6b35)"
+                    : "rgba(233,30,140,0.08)",
+                  color: (isMyTurn && !isSubmitting && pin.join("").length === 4) ? "#fff" : "#8a7a9e",
                   border: "none", fontWeight: 700,
                   cursor: (isMyTurn && !isSubmitting && pin.join("").length === 4) ? "pointer" : "not-allowed",
-                  boxShadow: (isMyTurn && !isSubmitting && pin.join("").length === 4) ? "0 4px 16px rgba(124,58,237,0.3)" : "none",
+                  boxShadow: (isMyTurn && !isSubmitting && pin.join("").length === 4) ? "0 4px 16px rgba(233,30,140,0.3)" : "none",
                   transition: "background 0.2s, box-shadow 0.2s",
                 }}
               >
@@ -485,21 +485,21 @@ function GamePage({ send, state }) {
             {isSystemGame ? "🤖" : "🎯"} {opponentName}
           </h3>
           <div style={{ marginBottom: 14 }}>
-            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: 1, marginBottom: 4 }}>Opponent's Number</div>
-            <div style={{ fontSize: 20, color: "#334155", fontWeight: 700 }}>🔒 Hidden</div>
+            <div style={{ color: "#8a7a9e", fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: 1, marginBottom: 4 }}>Opponent's Number</div>
+            <div style={{ fontSize: 20, color: "#5a4a6e", fontWeight: 700 }}>🔒 Hidden</div>
           </div>
           <div>
-            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: 1, marginBottom: 8 }}>
+            <div style={{ color: "#8a7a9e", fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: 1, marginBottom: 8 }}>
               {opponentName}'s Guesses
             </div>
             <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
               {(playerRole === "player1" ? player2Turns : player1Turns).length === 0 && (
-                <li style={{ color: "#334155", fontSize: 14 }}>No guesses yet.</li>
+                <li style={{ color: "#8a7a9e", fontSize: 14 }}>No guesses yet.</li>
               )}
               {(playerRole === "player1" ? player2Turns : player1Turns).map((t, idx) => (
                 <li key={idx} style={{ marginBottom: 8, display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
                   {renderGuess(t.guess)}
-                  <span style={{ fontSize: 12, color: "#64748b", marginLeft: 4 }}>
+                  <span style={{ fontSize: 12, color: "#8a7a9e", marginLeft: 4 }}>
                     ✓{t.correct_digits}d / ✓{t.correct_positions}p
                   </span>
                 </li>

--- a/frontend/src/pages/Game/ScratchPad.css
+++ b/frontend/src/pages/Game/ScratchPad.css
@@ -60,38 +60,38 @@
   color: #e57373;
 }
 
-/* ── Dark theme variant ──────────────────────────── */
+/* ── Holi variant (used in DailyChallenge) ───────── */
 .scratchpad-dark {
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.75);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(233, 30, 140, 0.2);
+  box-shadow: 0 4px 24px rgba(233, 30, 140, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
 
 .scratchpad-dark .scratchpad-title {
-  color: #fbbf24;
+  color: #e91e8c;
 }
 
 .scratchpad-dark .scratchpad-digit {
-  background: rgba(255, 255, 255, 0.07);
-  border-color: rgba(255, 255, 255, 0.15);
-  color: #f1f5f9;
+  background: rgba(255, 255, 255, 0.7);
+  border-color: rgba(233, 30, 140, 0.2);
+  color: #1a1a2e;
 }
 
 .scratchpad-dark .scratchpad-digit:hover {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: rgba(251, 191, 36, 0.4);
+  background: rgba(233, 30, 140, 0.08);
+  border-color: rgba(233, 30, 140, 0.45);
 }
 
 .scratchpad-dark .scratchpad-digit.tick {
-  background: rgba(16, 185, 129, 0.18);
-  border-color: #10b981;
-  color: #34d399;
+  background: rgba(34, 197, 94, 0.15);
+  border-color: #22c55e;
+  color: #16a34a;
 }
 
 .scratchpad-dark .scratchpad-digit.cross {
-  background: rgba(239, 68, 68, 0.12);
+  background: rgba(239, 68, 68, 0.1);
   border-color: #ef4444;
-  color: #f87171;
+  color: #dc2626;
 }

--- a/frontend/src/pages/Home/HomePage.module.css
+++ b/frontend/src/pages/Home/HomePage.module.css
@@ -5,16 +5,16 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: #0a0a1a;
+  background: #fffef0;
   position: relative;
-  color: #f1f5f9;
+  color: #1a1a2e;
   font-family: "Inter", "Segoe UI", system-ui, sans-serif;
   padding: 1.5rem 1rem 2rem 1rem;
   box-sizing: border-box;
   overflow-x: hidden;
 }
 
-/* Aurora blobs background */
+/* Holi color blobs background */
 .homePage::before {
   content: "";
   position: fixed;
@@ -22,7 +22,7 @@
   left: -10%;
   width: 60%;
   height: 60%;
-  background: radial-gradient(circle, rgba(124, 58, 237, 0.18) 0%, transparent 70%);
+  background: radial-gradient(circle, rgba(233, 30, 140, 0.18) 0%, transparent 70%);
   pointer-events: none;
   z-index: 0;
   animation: blobFloat 8s ease-in-out infinite;
@@ -35,7 +35,7 @@
   right: -10%;
   width: 50%;
   height: 50%;
-  background: radial-gradient(circle, rgba(6, 182, 212, 0.14) 0%, transparent 70%);
+  background: radial-gradient(circle, rgba(255, 107, 53, 0.16) 0%, transparent 70%);
   pointer-events: none;
   z-index: 0;
   animation: blobFloat 10s ease-in-out infinite reverse;
@@ -76,7 +76,7 @@
   letter-spacing: -1px;
   position: relative;
   z-index: 1;
-  background: linear-gradient(135deg, #a78bfa 0%, #06b6d4 60%, #f1f5f9 100%);
+  background: linear-gradient(135deg, #e91e8c 0%, #ff6b35 45%, #22c55e 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -87,7 +87,7 @@
 .subText {
   font-size: 1rem;
   margin-bottom: 1.5rem;
-  color: #94a3b8;
+  color: #5a4a6e;
   text-align: center;
   max-width: 480px;
   line-height: 1.65;
@@ -97,34 +97,34 @@
 }
 
 .brand {
-  color: #a78bfa;
+  color: #e91e8c;
   font-weight: 700;
-  -webkit-text-fill-color: #a78bfa;
+  -webkit-text-fill-color: #e91e8c;
 }
 
 .exciting {
-  color: #06b6d4;
+  color: #ff6b35;
   font-weight: 700;
-  -webkit-text-fill-color: #06b6d4;
+  -webkit-text-fill-color: #ff6b35;
 }
 
 .secret {
-  color: #f472b6;
+  color: #9c27b0;
   font-weight: 700;
-  -webkit-text-fill-color: #f472b6;
+  -webkit-text-fill-color: #9c27b0;
 }
 
 .challenge {
-  color: #a78bfa;
+  color: #e91e8c;
   font-weight: 700;
-  -webkit-text-fill-color: #a78bfa;
+  -webkit-text-fill-color: #e91e8c;
 }
 
 .ready {
   color: #fff;
   font-weight: 700;
   -webkit-text-fill-color: #fff;
-  background: linear-gradient(90deg, #7c3aed 0%, #06b6d4 100%);
+  background: linear-gradient(90deg, #e91e8c 0%, #ff6b35 100%);
   padding: 0 0.5em;
   border-radius: 6px;
   display: inline-block;
@@ -143,12 +143,12 @@
 
 /* ── Card base ──────────────────────────────────── */
 .card {
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.78);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(233, 30, 140, 0.18);
   border-radius: 18px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255,255,255,0.08);
+  box-shadow: 0 8px 32px rgba(233, 30, 140, 0.1), inset 0 1px 0 rgba(255,255,255,0.9);
   padding: 1.4rem 1.25rem 1.2rem;
   display: flex;
   flex-direction: column;
@@ -186,8 +186,8 @@
 }
 
 .card:hover {
-  border-color: rgba(124, 58, 237, 0.4);
-  box-shadow: 0 12px 44px rgba(124, 58, 237, 0.18), 0 0 0 1px rgba(124, 58, 237, 0.18);
+  border-color: rgba(233, 30, 140, 0.45);
+  box-shadow: 0 12px 44px rgba(233, 30, 140, 0.2), 0 0 0 1px rgba(233, 30, 140, 0.2);
   transform: translateY(-3px) scale(1.01);
 }
 
@@ -211,11 +211,11 @@
   margin: 0 0 0.4rem 0;
   font-size: 1.2rem;
   font-weight: 700;
-  color: #a78bfa;
+  color: #e91e8c;
 }
 
 .cardDesc {
-  color: #94a3b8;
+  color: #5a4a6e;
   margin-top: 2px;
   text-align: center;
   font-size: 0.88rem;
@@ -226,7 +226,7 @@
 .button {
   position: relative;
   overflow: hidden;
-  background: linear-gradient(135deg, #7c3aed 0%, #06b6d4 100%);
+  background: linear-gradient(135deg, #e91e8c 0%, #ff6b35 100%);
   color: #fff;
   border: none;
   border-radius: 10px;
@@ -234,7 +234,7 @@
   font-size: 0.95rem;
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 0 4px 16px rgba(124, 58, 237, 0.3);
+  box-shadow: 0 4px 16px rgba(233, 30, 140, 0.3);
   transition: box-shadow 0.2s, transform 0.12s;
   margin-top: 1rem;
   letter-spacing: 0.3px;
@@ -267,7 +267,7 @@
 
 .button:hover,
 .buttonActive {
-  box-shadow: 0 0 28px rgba(124, 58, 237, 0.55), 0 0 56px rgba(6, 182, 212, 0.2);
+  box-shadow: 0 0 28px rgba(233, 30, 140, 0.55), 0 0 56px rgba(255, 107, 53, 0.2);
   transform: translateY(-2px) scale(1.03);
 }
 
@@ -277,56 +277,56 @@
 
 /* ── Daily Challenge card ─────────────────────── */
 .cardDaily {
-  border-color: rgba(245, 158, 11, 0.18);
+  border-color: rgba(255, 215, 0, 0.35);
 }
 
 .cardDaily:hover {
-  border-color: rgba(245, 158, 11, 0.45);
-  box-shadow: 0 12px 44px rgba(245, 158, 11, 0.18), 0 0 0 1px rgba(245, 158, 11, 0.2);
+  border-color: rgba(255, 215, 0, 0.6);
+  box-shadow: 0 12px 44px rgba(255, 107, 53, 0.2), 0 0 0 1px rgba(255, 215, 0, 0.3);
 }
 
 .cardTitleDaily {
-  background: linear-gradient(135deg, #fbbf24 0%, #f97316 100%);
+  background: linear-gradient(135deg, #ffd700 0%, #ff6b35 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
 }
 
 .buttonDaily {
-  background: linear-gradient(135deg, #f59e0b 0%, #f97316 100%);
-  box-shadow: 0 4px 16px rgba(245, 158, 11, 0.3);
+  background: linear-gradient(135deg, #ffd700 0%, #ff6b35 100%);
+  box-shadow: 0 4px 16px rgba(255, 107, 53, 0.3);
 }
 
 .buttonDaily:hover,
 .buttonDaily.buttonActive {
-  box-shadow: 0 0 28px rgba(245, 158, 11, 0.55), 0 0 56px rgba(249, 115, 22, 0.2);
+  box-shadow: 0 0 28px rgba(255, 215, 0, 0.55), 0 0 56px rgba(255, 107, 53, 0.25);
 }
 
 /* ── Leaderboard card ─────────────────────────── */
 .cardLeaderboard {
-  border-color: rgba(167, 139, 250, 0.18);
+  border-color: rgba(34, 197, 94, 0.25);
 }
 
 .cardLeaderboard:hover {
-  border-color: rgba(167, 139, 250, 0.45);
-  box-shadow: 0 12px 44px rgba(167, 139, 250, 0.18), 0 0 0 1px rgba(167, 139, 250, 0.2);
+  border-color: rgba(34, 197, 94, 0.5);
+  box-shadow: 0 12px 44px rgba(34, 197, 94, 0.18), 0 0 0 1px rgba(34, 197, 94, 0.2);
 }
 
 .cardTitleLeaderboard {
-  background: linear-gradient(135deg, #a78bfa 0%, #818cf8 100%);
+  background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
 }
 
 .buttonLeaderboard {
-  background: linear-gradient(135deg, #7c3aed 0%, #818cf8 100%);
-  box-shadow: 0 4px 16px rgba(124, 58, 237, 0.3);
+  background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+  box-shadow: 0 4px 16px rgba(34, 197, 94, 0.3);
 }
 
 .buttonLeaderboard:hover,
 .buttonLeaderboard.buttonActive {
-  box-shadow: 0 0 28px rgba(167, 139, 250, 0.5), 0 0 56px rgba(129, 140, 248, 0.2);
+  box-shadow: 0 0 28px rgba(34, 197, 94, 0.5), 0 0 56px rgba(22, 163, 74, 0.2);
 }
 
 /* ── Tablet: 2-column ────────────────────────── */

--- a/frontend/src/pages/JoinGame/JoinGame.jsx
+++ b/frontend/src/pages/JoinGame/JoinGame.jsx
@@ -1,12 +1,12 @@
 import React, { useState } from "react";
 
 const glassCard = {
-  background: "rgba(255, 255, 255, 0.05)",
+  background: "rgba(255, 255, 255, 0.82)",
   backdropFilter: "blur(24px)",
   WebkitBackdropFilter: "blur(24px)",
-  border: "1px solid rgba(255, 255, 255, 0.1)",
+  border: "1px solid rgba(255, 107, 53, 0.22)",
   borderRadius: 20,
-  boxShadow: "0 8px 40px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.08)",
+  boxShadow: "0 8px 40px rgba(255,107,53,0.12), inset 0 1px 0 rgba(255,255,255,0.9)",
   padding: "40px 32px 32px 32px",
   minWidth: 340,
   maxWidth: 420,
@@ -20,12 +20,12 @@ const inputStyle = {
   width: "100%",
   padding: "12px 14px",
   borderRadius: 10,
-  border: "1.5px solid rgba(255,255,255,0.12)",
+  border: "1.5px solid rgba(255,107,53,0.22)",
   fontSize: 16,
   outline: "none",
   fontWeight: 500,
-  background: "rgba(255,255,255,0.06)",
-  color: "#f1f5f9",
+  background: "rgba(255,255,255,0.7)",
+  color: "#1a1a2e",
   transition: "border 0.2s, box-shadow 0.2s",
   boxSizing: "border-box",
 };
@@ -35,13 +35,13 @@ const btnPrimary = {
   fontSize: 17,
   padding: "12px 0",
   borderRadius: 10,
-  background: "linear-gradient(135deg, #7c3aed 0%, #06b6d4 100%)",
+  background: "linear-gradient(135deg, #ff6b35 0%, #e91e8c 100%)",
   color: "#fff",
   border: "none",
   fontWeight: 700,
   marginTop: 8,
   cursor: "pointer",
-  boxShadow: "0 4px 20px rgba(124, 58, 237, 0.35)",
+  boxShadow: "0 4px 20px rgba(255, 107, 53, 0.35)",
   transition: "box-shadow 0.2s, transform 0.12s",
   letterSpacing: "0.4px",
 };
@@ -51,9 +51,9 @@ const btnSecondary = {
   fontSize: 15,
   padding: "10px 0",
   borderRadius: 10,
-  background: "rgba(255,255,255,0.06)",
-  color: "#94a3b8",
-  border: "1px solid rgba(255,255,255,0.1)",
+  background: "rgba(255,107,53,0.06)",
+  color: "#5a4a6e",
+  border: "1px solid rgba(255,107,53,0.15)",
   fontWeight: 600,
   marginTop: 14,
   cursor: "pointer",
@@ -91,7 +91,7 @@ function JoinGamePage({ send }) {
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        background: "#0a0a1a",
+        background: "#fffef0",
         padding: "20px",
         fontFamily: "Inter, Segoe UI, system-ui, sans-serif",
         position: "relative",
@@ -101,12 +101,12 @@ function JoinGamePage({ send }) {
       {/* Ambient blobs */}
       <div style={{
         position: "fixed", top: "-15%", right: "-10%", width: "55%", height: "55%",
-        background: "radial-gradient(circle, rgba(6,182,212,0.14) 0%, transparent 70%)",
+        background: "radial-gradient(circle, rgba(255,107,53,0.18) 0%, transparent 70%)",
         pointerEvents: "none", zIndex: 0,
       }} />
       <div style={{
         position: "fixed", bottom: "-10%", left: "-10%", width: "45%", height: "45%",
-        background: "radial-gradient(circle, rgba(124,58,237,0.12) 0%, transparent 70%)",
+        background: "radial-gradient(circle, rgba(233,30,140,0.14) 0%, transparent 70%)",
         pointerEvents: "none", zIndex: 0,
       }} />
 
@@ -119,17 +119,17 @@ function JoinGamePage({ send }) {
           }
         }
         .join-game-input:focus {
-          border-color: rgba(6,182,212,0.7) !important;
-          box-shadow: 0 0 0 3px rgba(6,182,212,0.15) !important;
+          border-color: rgba(255,107,53,0.7) !important;
+          box-shadow: 0 0 0 3px rgba(255,107,53,0.15) !important;
         }
-        .join-game-input::placeholder { color: #4b5563; }
+        .join-game-input::placeholder { color: #8a7a9e; }
         .btn-join-glow:hover {
-          box-shadow: 0 0 32px rgba(6,182,212,0.5), 0 0 64px rgba(124,58,237,0.2) !important;
+          box-shadow: 0 0 32px rgba(255,107,53,0.5), 0 0 64px rgba(233,30,140,0.2) !important;
           transform: translateY(-1px);
         }
         .btn-join-secondary:hover {
-          background: rgba(255,255,255,0.1) !important;
-          color: #f1f5f9 !important;
+          background: rgba(255,107,53,0.08) !important;
+          color: #1a1a2e !important;
         }
       `}</style>
 
@@ -137,14 +137,14 @@ function JoinGamePage({ send }) {
         {/* Top accent bar — cyan leading */}
         <div style={{
           position: "absolute", top: 0, left: 0, right: 0, height: 3,
-          background: "linear-gradient(90deg, #06b6d4 0%, #7c3aed 100%)",
+          background: "linear-gradient(90deg, #ff6b35 0%, #e91e8c 100%)",
           borderRadius: "20px 20px 0 0",
         }} />
 
-        <h2 style={{ fontWeight: 800, fontSize: 26, marginBottom: 8, color: "#67e8f9", letterSpacing: 0.5 }}>
+        <h2 style={{ fontWeight: 800, fontSize: 26, marginBottom: 8, color: "#ff6b35", letterSpacing: 0.5 }}>
           🔗 Join a Game
         </h2>
-        <div style={{ color: "#64748b", marginBottom: 24, fontSize: 14.5, lineHeight: 1.65 }}>
+        <div style={{ color: "#5a4a6e", marginBottom: 24, fontSize: 14.5, lineHeight: 1.65 }}>
           Enter the Game ID shared by your friend,<br />
           your name, and a secret 4-digit number.<br />
           <span style={{ color: "#f59e0b", fontWeight: 600 }}>All digits must be unique!</span>

--- a/frontend/src/pages/Leaderboard/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard/Leaderboard.jsx
@@ -52,9 +52,9 @@ export default function Leaderboard() {
   }, [fetchLeaderboard]);
 
   const ghostBtnStyle = {
-    background: "rgba(255,255,255,0.07)",
-    color: "#94a3b8",
-    border: "1px solid rgba(255,255,255,0.1)",
+    background: "rgba(255,255,255,0.6)",
+    color: "#5a4a6e",
+    border: "1px solid rgba(233,30,140,0.15)",
     borderRadius: 8,
     padding: "0.5rem 1rem",
     fontSize: "0.88rem",
@@ -66,8 +66,8 @@ export default function Leaderboard() {
     <div
       style={{
         minHeight: "100vh",
-        background: "#0a0a1a",
-        color: "#f1f5f9",
+        background: "#fffef0",
+        color: "#1a1a2e",
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
@@ -86,7 +86,7 @@ export default function Leaderboard() {
           right: "-10%",
           width: "50%",
           height: "50%",
-          background: "radial-gradient(circle, rgba(245,158,11,0.12) 0%, transparent 70%)",
+          background: "radial-gradient(circle, rgba(255,215,0,0.2) 0%, transparent 70%)",
           pointerEvents: "none",
           zIndex: 0,
         }}
@@ -98,7 +98,7 @@ export default function Leaderboard() {
           left: "-10%",
           width: "45%",
           height: "45%",
-          background: "radial-gradient(circle, rgba(124,58,237,0.1) 0%, transparent 70%)",
+          background: "radial-gradient(circle, rgba(233,30,140,0.12) 0%, transparent 70%)",
           pointerEvents: "none",
           zIndex: 0,
         }}
@@ -122,7 +122,7 @@ export default function Leaderboard() {
         </button>
         <button
           onClick={() => navigate("/daily")}
-          style={{ ...ghostBtnStyle, color: "#fbbf24" }}
+          style={{ ...ghostBtnStyle, color: "#ff6b35" }}
         >
           ⚡ Play Today
         </button>
@@ -135,7 +135,7 @@ export default function Leaderboard() {
             fontSize: "2.2rem",
             fontWeight: 800,
             margin: "0 0 0.25rem",
-            background: "linear-gradient(135deg, #fbbf24 0%, #f97316 50%, #a78bfa 100%)",
+            background: "linear-gradient(135deg, #e91e8c 0%, #ffd700 50%, #22c55e 100%)",
             WebkitBackgroundClip: "text",
             WebkitTextFillColor: "transparent",
             backgroundClip: "text",
@@ -144,7 +144,7 @@ export default function Leaderboard() {
           🏆 Daily Leaderboard
         </h1>
         {date && (
-          <p style={{ color: "#64748b", margin: "4px 0 0", fontSize: "0.88rem" }}>
+          <p style={{ color: "#8a7a9e", margin: "4px 0 0", fontSize: "0.88rem" }}>
             {formatDate(date)}
           </p>
         )}
@@ -153,12 +153,12 @@ export default function Leaderboard() {
       {/* Leaderboard card */}
       <div
         style={{
-          background: "rgba(255,255,255,0.05)",
+          background: "rgba(255,255,255,0.8)",
           backdropFilter: "blur(20px)",
           WebkitBackdropFilter: "blur(20px)",
-          border: "1px solid rgba(255,255,255,0.1)",
+          border: "1px solid rgba(233,30,140,0.18)",
           borderRadius: 18,
-          boxShadow: "0 8px 32px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.08)",
+          boxShadow: "0 8px 32px rgba(233,30,140,0.1), inset 0 1px 0 rgba(255,255,255,0.9)",
           width: "100%",
           maxWidth: 560,
           overflow: "hidden",
@@ -173,10 +173,10 @@ export default function Leaderboard() {
             justifyContent: "space-between",
             alignItems: "center",
             padding: "1rem 1.5rem",
-            borderBottom: "1px solid rgba(255,255,255,0.07)",
+            borderBottom: "1px solid rgba(233,30,140,0.1)",
           }}
         >
-          <span style={{ color: "#94a3b8", fontSize: "0.88rem" }}>
+          <span style={{ color: "#5a4a6e", fontSize: "0.88rem" }}>
             {entries.length} {entries.length === 1 ? "player" : "players"} completed today
           </span>
           <button
@@ -206,11 +206,11 @@ export default function Leaderboard() {
             style={{
               padding: "3rem 1.5rem",
               textAlign: "center",
-              color: "#64748b",
+              color: "#8a7a9e",
             }}
           >
             <div style={{ fontSize: "2.5rem", marginBottom: 12 }}>🎯</div>
-            <p style={{ margin: 0, fontWeight: 600, color: "#94a3b8" }}>
+            <p style={{ margin: 0, fontWeight: 600, color: "#5a4a6e" }}>
               No completions yet!
             </p>
             <p style={{ margin: "6px 0 1.5rem", fontSize: "0.88rem" }}>
@@ -219,7 +219,7 @@ export default function Leaderboard() {
             <button
               onClick={() => navigate("/daily")}
               style={{
-                background: "linear-gradient(135deg, #7c3aed 0%, #06b6d4 100%)",
+                background: "linear-gradient(135deg, #e91e8c 0%, #ff6b35 100%)",
                 color: "#fff",
                 border: "none",
                 borderRadius: 10,
@@ -244,12 +244,12 @@ export default function Leaderboard() {
                 gridTemplateColumns: "48px 1fr 80px 80px",
                 gap: 8,
                 padding: "0.6rem 1.5rem",
-                color: "#64748b",
+                color: "#8a7a9e",
                 fontSize: "0.75rem",
                 fontWeight: 600,
                 textTransform: "uppercase",
                 letterSpacing: "0.06em",
-                borderBottom: "1px solid rgba(255,255,255,0.05)",
+                borderBottom: "1px solid rgba(233,30,140,0.08)",
               }}
             >
               <span>Rank</span>
@@ -261,8 +261,8 @@ export default function Leaderboard() {
             {/* Rows */}
             {entries.map((entry, i) => {
               const isTop3 = entry.rank <= 3;
-              const rankColors = ["#fbbf24", "#94a3b8", "#cd7c2e"];
-              const rowColor = isTop3 ? rankColors[entry.rank - 1] : "#64748b";
+              const rankColors = ["#fbbf24", "#5a4a6e", "#cd7c2e"];
+              const rowColor = isTop3 ? rankColors[entry.rank - 1] : "#8a7a9e";
 
               return (
                 <div
@@ -274,7 +274,7 @@ export default function Leaderboard() {
                     padding: "0.85rem 1.5rem",
                     borderBottom:
                       i < entries.length - 1
-                        ? "1px solid rgba(255,255,255,0.04)"
+                        ? "1px solid rgba(233,30,140,0.07)"
                         : "none",
                     background: isTop3 ? `rgba(${entry.rank === 1 ? "251,191,36" : entry.rank === 2 ? "148,163,184" : "205,124,46"},0.04)` : "transparent",
                     alignItems: "center",
@@ -296,7 +296,7 @@ export default function Leaderboard() {
                   <span
                     style={{
                       fontWeight: isTop3 ? 700 : 500,
-                      color: isTop3 ? "#f1f5f9" : "#94a3b8",
+                      color: isTop3 ? "#1a1a2e" : "#5a4a6e",
                       overflow: "hidden",
                       textOverflow: "ellipsis",
                       whiteSpace: "nowrap",
@@ -310,7 +310,7 @@ export default function Leaderboard() {
                     style={{
                       textAlign: "center",
                       fontWeight: 700,
-                      color: isTop3 ? rowColor : "#64748b",
+                      color: isTop3 ? rowColor : "#8a7a9e",
                       fontVariantNumeric: "tabular-nums",
                     }}
                   >
@@ -321,7 +321,7 @@ export default function Leaderboard() {
                   <span
                     style={{
                       textAlign: "right",
-                      color: isTop3 ? "#a78bfa" : "#64748b",
+                      color: isTop3 ? "#e91e8c" : "#8a7a9e",
                       fontWeight: isTop3 ? 700 : 500,
                       fontVariantNumeric: "tabular-nums",
                       fontSize: "0.9rem",
@@ -340,7 +340,7 @@ export default function Leaderboard() {
       {lastRefreshed && (
         <p
           style={{
-            color: "#334155",
+            color: "#8a7a9e",
             fontSize: "0.75rem",
             marginTop: 12,
             position: "relative",


### PR DESCRIPTION
Replace dark navy theme with a vibrant Holi-inspired palette:
- Background: warm cream (#fffef0) instead of dark navy
- Primary accent: hot pink (#e91e8c) instead of violet
- Secondary accent: saffron/orange (#ff6b35) instead of cyan
- Player palettes: pink (P1), green (P2), orange (system)
- Glass cards: translucent white with colorful borders
- Gradient heading: pink → orange → green (Holi colors)
- Leaderboard: green card variant for festive feel
- Daily Challenge: yellow → orange gradient for sunny festivity
- All text updated for readability on light background
- Ambient background blobs now use Holi colors throughout

https://claude.ai/code/session_018GwtKrxcoHkgp6WAKMsLmu